### PR TITLE
fix garbled bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,11 @@
 !.gitignore
 !windows-dlls/*
 !windows-dlls/
+!tests/
+!tests/*
 !config.m4
 !core.h
 !php_tonyenc.h
 !tonyenc.c
 !tonyenc.php
 !README.md
-!tests/*

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 !tonyenc.c
 !tonyenc.php
 !README.md
+!tests/*

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## 介绍
 
-一个简洁、高性能、跨平台的 PHP7 代码加密扩展，当前版本为 0.2.2
+一个简洁、高性能、跨平台的 PHP7 代码加密扩展，当前版本为 0.2.3
 
 ## 特点
 
@@ -53,7 +53,7 @@ php_tonyenc_php70_ts_VC14_x64.dll
 # php7.0 64位 线程非安全版
 php_tonyenc_php70_nts_VC14_x64.dll
 ```
-[手动编译方法](http://lihancong.cn/blog/article/104)
+手动编译方法见 issues
 
 
 ## 加密

--- a/README.md
+++ b/README.md
@@ -66,6 +66,6 @@ php tonyenc.php example.php dir/
 
 ## 版权
 
-允许转载、修改、商用，请注明原作者及网址：Tony (http://htmln.com/)
+允许转载、修改、商用
 
 这是我开发的第一个扩展，如有不足欢迎指正 :)

--- a/core.h
+++ b/core.h
@@ -42,7 +42,6 @@ void tonyenc_decode(char *, size_t);
 zend_op_array *cgi_compile_file(zend_file_handle *file_handle, int type)
 {
     FILE *fp;
-    zend_string *opened_path;
     struct stat stat_buf;
     int data_len;
     TONYENC_RES res = 0;
@@ -58,7 +57,8 @@ zend_op_array *cgi_compile_file(zend_file_handle *file_handle, int type)
     }
 
     if (file_handle->filename) {
-        fp = zend_fopen(file_handle->filename, &opened_path);
+    	 char *file_path = ZSTR_VAL(file_handle->opened_path);
+        fp = fopen(file_path, "r");
         if (fp == NULL)
             goto final;
     }

--- a/core.h
+++ b/core.h
@@ -57,7 +57,7 @@ zend_op_array *cgi_compile_file(zend_file_handle *file_handle, int type)
     }
 
     if (file_handle->filename) {
-    	 char *file_path = ZSTR_VAL(file_handle->opened_path);
+    	char *file_path = ZSTR_VAL(file_handle->opened_path);
         fp = fopen(file_path, "r");
         if (fp == NULL)
             goto final;

--- a/core.h
+++ b/core.h
@@ -58,7 +58,7 @@ zend_op_array *cgi_compile_file(zend_file_handle *file_handle, int type)
 
     if (file_handle->filename) {
     	 char *file_path = ZSTR_VAL(file_handle->opened_path);
-        fp = fopen(file_path, "r");
+        fp = zend_fopen(file_handle->filename, NULL);
         if (fp == NULL)
             goto final;
     }

--- a/core.h
+++ b/core.h
@@ -57,7 +57,7 @@ zend_op_array *cgi_compile_file(zend_file_handle *file_handle, int type)
     }
 
     if (file_handle->filename) {
-    	char *file_path = ZSTR_VAL(file_handle->opened_path);
+    	 char *file_path = ZSTR_VAL(file_handle->opened_path);
         fp = fopen(file_path, "r");
         if (fp == NULL)
             goto final;

--- a/php_tonyenc.h
+++ b/php_tonyenc.h
@@ -24,7 +24,7 @@
 extern zend_module_entry tonyenc_module_entry;
 #define phpext_tonyenc_ptr &tonyenc_module_entry
 
-#define PHP_TONYENC_VERSION "0.2.2" /* Replace with version number for your extension */
+#define PHP_TONYENC_VERSION "0.2.3" /* Replace with version number for your extension */
 
 #ifdef PHP_WIN32
 #   define PHP_TONYENC_API __declspec(dllexport)

--- a/tests/001.phpt
+++ b/tests/001.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Check if tonyenc is loaded
+--SKIPIF--
+<?php
+if (!extension_loaded('tonyenc')) {
+	echo 'skip';
+}
+?>
+--FILE--
+<?php
+echo 'The extension "tonyenc" is available';
+?>
+--EXPECT--
+The extension "tonyenc" is available

--- a/tests/002.phpt
+++ b/tests/002.phpt
@@ -1,0 +1,14 @@
+--TEST--
+tonyenc_encode() exists test
+--SKIPIF--
+<?php
+if (!function_exists('tonyenc_encode')) {
+	echo 'skip';
+}
+?>
+--FILE--
+<?php
+	echo "The function tonyenc_encode is exists!";
+?>
+--EXPECT--
+The function tonyenc_encode is exists!


### PR DESCRIPTION
#19 修复内存泄漏问题后导致乱码

按照zend_fopen的实现，实际上第二个参数传NULL即可